### PR TITLE
✏️Removing Elytra drop on death + give it back.

### DIFF
--- a/plugin/src/main/java/me/lemonypancakes/originsbukkit/listeners/origins/Elytrian.java
+++ b/plugin/src/main/java/me/lemonypancakes/originsbukkit/listeners/origins/Elytrian.java
@@ -441,4 +441,29 @@ public class Elytrian extends Origin implements Listener {
                 .getListenerHandler()
                 .getPlugin());
     }
+    
+    @EventHandler
+    private void elytrianDeath(PlayerDeathEvent event) {
+        Entity entity = event.getEntity();
+
+        if(entity instanceof Player) {
+            Player player = (Player) entity;
+            OriginPlayer originPlayer = new OriginPlayer(player);
+            String playerOrigin = originPlayer.getOrigin();
+            if(playerOrigin == Origins.ELYTRIAN.toString()) {
+            for (ItemStack i : event.getDrops()) if(i.getType() == Material.ELYTRA) i.setType(Material.AIR);
+            };
+        }
+    }
+
+    @EventHandler
+    private void elytrianRespawn(PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+        OriginPlayer originPlayer = new OriginPlayer(player);
+        String playerOrigin = originPlayer.getOrigin();
+        if(playerOrigin == Origins.ELYTRIAN.toString()) {
+        elytrianElytra(player);
+        };
+    }
+
 }


### PR DESCRIPTION
This commit fixes a duplication bug noticed in #5.
This commit set's the elytra drop when player dies to the Air material and re give the elytra when the player respawns.

I also recommend having a develop or development branch where you can push alpha / beta changes while maintaining the current stable version files.